### PR TITLE
ci: use setup-node NPM cache

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,6 +24,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
+        cache: npm
     - run: npm ci
-    - run: npm run build --if-present
     - run: npm test


### PR DESCRIPTION
Use the NPM cache and removed the unused `build` that came from the old CI job template