### PR TITLE
chore: Add npmignore for test/ci files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.github/
+node_modules/
+invalid.md
+test.js
+valid.md


### PR DESCRIPTION
Don't think this improves a whole bunch, but trims it down to the following after `npm pack`
![image](https://github.com/user-attachments/assets/37b75a2b-9ebb-4fb7-b100-179f04257a34)

